### PR TITLE
Respect birthday visibility setting

### DIFF
--- a/app/Console/Commands/DistributeBirthdayReward.php
+++ b/app/Console/Commands/DistributeBirthdayReward.php
@@ -54,7 +54,7 @@ class DistributeBirthdayReward extends Command
         $item = Item::where('id', Settings::get('birthday_item'))->first();
 
         // For each user
-        forEach($birthdayUsers as $user) {
+        foreach($birthdayUsers as $user) {
             try {
                 // Exclude users whose birthdays are fully hidden
                 if ($user->settings->birthday_setting > 0) {
@@ -67,15 +67,17 @@ class DistributeBirthdayReward extends Command
                     // you can change this as well, we're setting it to a birthday message as default because it's cute
                     $data = 'Happy Birthday, '. $user->displayName .'!';
 
-                    (new InventoryManager)->creditItem(null, $user, $logType, [
+                    if(!(new InventoryManager)->creditItem(null, $user, $logType, [
                     'data' => $data,
                     'notes' => null,
-                    ], $item, 1);
+                    ], $item, 1)) {
+                        $this->error('Failed to distribute birthday reward.');
+                    }
                 }
             } catch(\Exception $e) {
                 $this->error('error:'. $e->getMessage());
             }
-    }
+        }
     $this->info('Rewards have been distributed');
 }
 }

--- a/app/Console/Commands/DistributeBirthdayReward.php
+++ b/app/Console/Commands/DistributeBirthdayReward.php
@@ -3,13 +3,10 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
-use Config;
-use DB;
-use Carbon\Carbon;
 use App\Models\User\User;
  use App\Models\Item\Item;
 use App\Services\InventoryManager;
-use Settings;
+use App\Facades\Settings;
 
 class DistributeBirthdayReward extends Command
 {
@@ -49,32 +46,32 @@ class DistributeBirthdayReward extends Command
         $this->info('*******************************');
 
         // Get users with a birthday for the given month
-        //it grants on the first of the month every month, it prevents players from having their exact day given out if they don't want to 
-        //may add a setting later where players can opt out of rewards if they don't want even the month to be public
+        // it grants on the first of the month every month, it prevents players from having their exact day given out if they don't want to
+        // may add a setting later where players can opt out of rewards if they don't want even the month to be public
         $birthdayUsers = User::whereRaw('MONTH(birthday) = MONTH(NOW())')->get();
-         //this is what will be granted to EVERY user, there is no tweaking it, so if you want to put some randomness in here, just make the selected ID a box with a loot table
+
+        // this is what will be granted to EVERY user, there is no tweaking it, so if you want to put some randomness in here, just make the selected ID a box with a loot table
         $item = Item::where('id', Settings::get('birthday_item'))->first();
-    
+
         // For each user
         forEach($birthdayUsers as $user) {
-            
-
             try {
-                //this is what the "log type" will be in the logs
-                //it's usually something like "staff grant", "shop purchase" 
-                //you can change this if you want
-                $logType = 'Birthday Reward';
-                //this is what appears after the log type, it will also show up as the source if it's an item, so you can take it out if you really want, just set it to null, don't outright remove it or it will break
-                //usually it is "recieved item from X", "purchased from X by for (X currency)"
-                //you can change this as well, we're setting it to a birthday message as default because it's cute 
-                $data = 'Happy Birthday, '. $user->displayName .'!';
-                   
-                  (new InventoryManager)->creditItem(null, $user, $logType, [
-                   'data' => $data,
-                   'notes' => null, ],
-                  $item, 1);            
-                
-                
+                // Exclude users whose birthdays are fully hidden
+                if ($user->settings->birthday_setting > 0) {
+                    // this is what the "log type" will be in the logs
+                    // it's usually something like "staff grant", "shop purchase"
+                    // you can change this if you want
+                    $logType = 'Birthday Reward';
+                    // this is what appears after the log type, it will also show up as the source if it's an item, so you can take it out if you really want, just set it to null, don't outright remove it or it will break
+                    // usually it is "recieved item from X", "purchased from X by for (X currency)"
+                    // you can change this as well, we're setting it to a birthday message as default because it's cute
+                    $data = 'Happy Birthday, '. $user->displayName .'!';
+
+                    (new InventoryManager)->creditItem(null, $user, $logType, [
+                    'data' => $data,
+                    'notes' => null,
+                    ], $item, 1);
+                }
             } catch(\Exception $e) {
                 $this->error('error:'. $e->getMessage());
             }

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -180,11 +180,11 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasMany('App\Models\Gallery\GalleryFavorite')->where('user_id', $this->id);
     }
-    
+
     /**
      * Get all of the user's character bookmarks.
      */
-    public function bookmarks() 
+    public function bookmarks()
     {
         return $this->hasMany('App\Models\Character\CharacterBookmark')->where('user_id', $this->id);
     }
@@ -368,6 +368,12 @@ class User extends Authenticatable implements MustVerifyEmail
             case 3:
                 return $bday->format('d M Y') . $icon;
             break;
+            case 4:
+                if(Auth::check()) return $bday->format('M');
+            break;
+            case 5:
+                return $bday->format('M');
+            break;
         }
     }
 
@@ -376,7 +382,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function getcheckBirthdayAttribute()
     {
-        $bday = $this->birthday; 
+        $bday = $this->birthday;
         if(!$bday || $bday->diffInYears(carbon::now()) < 13) return false;
         else return true;
     }

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -43,7 +43,7 @@
         <div class="form-group row">
             <label class="col-md-2 col-form-label">Setting</label>
             <div class="col-md-10">
-                {!! Form::select('birthday_setting', ['0' => '0: No one can see your birthday.', '1' => '1: Members can see your day and month.', '2' => '2: Anyone can see your day and month.', '3' => '3: Full date public.'],Auth::user()->settings->birthday_setting, ['class' => 'form-control']) !!}
+                {!! Form::select('birthday_setting', ['0' => '0: No one can see your birthday.', '1' => '1: Members can see your day and month.', '2' => '2: Anyone can see your day and month.', '3' => '3: Full date public.', '4' => '4: Members can see the month.', '5' => '5: Anyone can see the month.'],Auth::user()->settings->birthday_setting, ['class' => 'form-control']) !!}
             </div>
         </div>
         <div class="text-right">


### PR DESCRIPTION
As it says on the tin. All options other than no visibility display at least the month, so in essence, this just disables the automatic reward if the user's birthday is completely hidden.
Also adds the option to display only the month, either to members only or to everyone. While ordinarily this might not be necessary, in this instance where there's functionality tied to it, it seems appropriate to have an opt-in that betrays only the minimum required information.
Shouldn't require any action!