### PR TITLE
Various Fixes & Tweaks

### DIFF
--- a/app/Http/Controllers/WorldController.php
+++ b/app/Http/Controllers/WorldController.php
@@ -542,7 +542,7 @@ class WorldController extends Controller
         $bottom = Border::find($request->input('bottom'));
 
         if (!$border || !$top || !$bottom) {
-            return response('<hr class="w-75" />Select a valid combination to preview.');
+            return response('<hr class="w-75 d-none d-md-block"/>Select a valid combination to preview.');
         }
 
         return view('world._border_ajax', [

--- a/app/Models/Border/Border.php
+++ b/app/Models/Border/Border.php
@@ -299,18 +299,18 @@ class Border extends Model
         //we will preview the border on various site pages for purposes of fun :}
         //and so people can "test" their look without having to unlock one
         //if we pass $id, return the avatar of that user
-
         if ($id) {
             $user = User::find($id)->avatarUrl;
-
+            $name = 'Avatar of ' . User::find($id)->name;
             //else, check if logged in
             //if logged in, return the user avatar to preview
         } elseif (Auth::check()) {
             $user = Auth::user()->avatarUrl;
-
+            $name = 'Avatar of ' . Auth::user()->name;
             //finally if not either of these, return default avatar
         } else {
             $user = url('images/avatars/default.jpg');
+            $name = 'Default Avatar';
         }
         //basically just an ugly ass string of html for copypasting use
         //would you want to keep posting this everywhere? yeah i thought so. me neither
@@ -319,42 +319,15 @@ class Border extends Model
 
         //get some fun variables for later
         $avatar = '<!-- avatar -->
-        <img class="avatar" src="' .
-            $user .
-            '" style="position: absolute; border-radius:50%; width:125px; height:125px;">';
+                <img class="avatar" src="' . $user . '" alt="' . $name . '">';
 
-        $styling = '<div style="width:125px; height:125px; border-radius:50%; margin-right:25px;">
-    ';
+        $styling = '<div class="user-avatar">';
+        $layer = ($this->border_style == 0 ? 'under' : ' ');
 
         $frame = '<!-- frame -->
-                    <img src="' .
-        $this->imageUrl .
-            '" style="position: absolute;width:125px; height:125px;"  alt="avatar frame">';
+                <img src="' . $this->imageUrl . '" class="avatar-border ' . $layer . '" alt="' . $this->name . ' Avatar Frame">';
 
-        //first check the frame style
-
-        //under style
-        if ($this->border_style) {
-            return $styling .
-                '' .
-                $avatar .
-                '
-           ' .
-                $frame .
-                '
-        </div>';
-
-            //then over style
-        } else {
-            return $styling .
-                '' .
-                $frame .
-                '
-           ' .
-                $avatar .
-                '
-        </div>';
-        }
+        return $styling . $avatar . $frame . '</div>';
     }
 
     /**
@@ -366,48 +339,54 @@ class Border extends Model
         //we will preview the border on various site pages for purposes of fun :}
         //and so people can "test" their look without having to unlock one
         //if we pass $id, return the avatar of that user
-
         if ($id) {
             $user = User::find($id)->avatarUrl;
-
+            $name = 'Avatar of ' . User::find($id)->name;
             //else, check if logged in
             //if logged in, return the user avatar to preview
         } elseif (Auth::check()) {
             $user = Auth::user()->avatarUrl;
-
+            $name = 'Avatar of ' . Auth::user()->name;
             //finally if not either of these, return default avatar
         } else {
             $user = url('images/avatars/default.jpg');
+            $name = 'Default Avatar';
         }
         //basically just an ugly ass string of html for copypasting use
         //would you want to keep posting this everywhere? yeah i thought so. me neither
         //there's probably a less hellish way to do this but it beats having to paste this over everywhere... EVERY SINGLE TIME.
         //especially with the checks
 
-        $height = '125px';
-
         //get some fun variables for later
         $avatar = '<!-- avatar -->
-        <img class="avatar" src="' .
-            $user .
-            '" style="position: absolute; border-radius:50%; width:' . $height . '; height:' . $height . ';" >';
+                <img class="avatar" src="' . $user . '" alt="' . $name . '">';
 
-        $styling = '<div style="width:' . $height . '; height:' . $height . '; border-radius:50%; margin-right:25px;">';
+        $styling = '<div class="user-avatar">';
 
-        //top's layer image
-        $mainframe = '<img src="' . $top->imageUrl .
-            '" style="position: absolute;width:' . $height . '; height:' . $height . ';">';
-        //bottom layer's image
-        $secondframe = '<img src="' . $bottom->imageUrl .
-            '" style="position: absolute;width:' . $height . '; height:' . $height . ';">';
-
-        if ($top->border_style && $bottom->border_style) {
-            return $styling . $avatar . $secondframe . $mainframe . '</div>';
-        } elseif ($top->border_style && !$bottom->border_style) {
-            return $styling . $secondframe . $avatar . $mainframe . '</div>';
+        if ($top->border_style == 0 && $bottom->border_style == 0) {
+            // If both layers are UNDER the avatar
+            //top's layer image
+            $mainframe = '<img src="' . $top->imageUrl . '" class="avatar-border under" alt="' . $this->name . ' Avatar Frame">';
+            //bottom layer's image
+            $secondframe = '<img src="' . $bottom->imageUrl . '" class="avatar-border bottom" alt="' . $this->name . ' Avatar Frame">';
+        } elseif ($top->border_style == 1 && $bottom->border_style == 1) {
+            // If both layers are OVER the avatar
+            //top's layer image
+            $mainframe = '<img src="' . $top->imageUrl . '" class="avatar-border top" alt="' . $this->name . ' Avatar Frame">';
+            //bottom layer's image
+            $secondframe = '<img src="' . $bottom->imageUrl . '" class="avatar-border" alt="' . $this->name . ' Avatar Frame">';
         } else {
-            return $styling . $secondframe . $mainframe . $avatar . '</div>';
+            // If one layer is UNDER and one is OVER the avatar
+            $mainlayer = ($top->border_style == 0 ? 'under' : ' ');
+            $secondlayer = ($bottom->border_style == 0 ? 'under' : ' ');
+
+            //top's layer image
+            $mainframe = '<img src="' . $top->imageUrl . '" class="avatar-border ' . $mainlayer . '" alt="' . $this->name . ' Avatar Frame">';
+            //bottom layer's image
+            $secondframe = '<img src="' . $bottom->imageUrl . '" class="avatar-border ' . $secondlayer . '" alt="' . $this->name . ' Avatar Frame">';
         }
+
+        return $styling . $avatar . $mainframe . $secondframe . '</div>';
     }
 
     /**

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -721,63 +721,61 @@ class User extends Authenticatable implements MustVerifyEmail
         //there's probably a less hellish way to do this but it beats having to paste this over everywhere... EVERY SINGLE TIME.
         //especially with the checks
 
-        $height = '125px';
-
         //get some fun variables for later
         $avatar = '<!-- avatar -->
-        <img class="avatar" src="' .
-        $this->avatarUrl .
-        '" style="position: absolute; border-radius:50%; width:' . $height . '; height:' . $height . ';" alt="' .
-        $this->name .
-            '">';
+                <img class="avatar" src="' . $this->avatarUrl . '" alt="Avatar of ' . $this->name . '">';
 
-        $styling = '<div style="width:' . $height . '; height:' . $height . '; border-radius:50%; margin-right:25px;">
-    ';
+        // Check if variant border or regular border is under or over
+        if (isset($this->borderVariant) && $this->borderVariant->border_style == 0) {
+            $layer = 'under';
+        } elseif (isset($this->border) && $this->border->border_style == 0) {
+            $layer = 'under';
+        } else {
+            $layer = null;
+        }
+
+        $styling = '<div class="user-avatar">';
 
         //if the user has a border, we apply it
         if (isset($this->border) || isset($this->borderBottomLayer) && isset($this->borderTopLayer) || isset($this->borderVariant)) {
-
             //layers supersede variants
             //variants supersede regular borders
             if (isset($this->borderBottomLayer) && isset($this->borderTopLayer)) {
-                //top's layer image
-                $mainframe = '<img src="' . $this->borderTopLayer->imageUrl .
-                    '" style="position: absolute;width:' . $height . '; height:' . $height . ';">';
-                //bottom layer's image
-                $secondframe = '<img src="' . $this->borderBottomLayer->imageUrl .
-                    '" style="position: absolute;width:' . $height . '; height:' . $height . ';">';
-
-                if ($this->borderTopLayer->border_style && $this->borderBottomLayer->border_style) {
-                    return $styling . $avatar . $secondframe . $mainframe . '</div>';
-                } elseif ($this->borderTopLayer->border_style && !$this->borderBottomLayer->border_style) {
-                    return $styling . $secondframe . $avatar . $mainframe . '</div>';
+                if ($this->borderTopLayer->border_style == 0 && $this->borderBottomLayer->border_style == 0) {
+                    // If both layers are UNDER layers
+                    // top layer's image
+                    $mainframe = '<img src="' . $this->borderTopLayer->imageUrl . '" class="avatar-border under" alt="' . $this->borderTopLayer->name . ' Avatar Frame">';
+                    // bottom layer's image
+                    $secondframe = '<img src="' . $this->borderBottomLayer->imageUrl . '" class="avatar-border bottom" alt="' . $this->borderBottomLayer->name . ' Avatar Frame">';
+                } elseif ($this->borderTopLayer->border_style == 1 && $this->borderBottomLayer->border_style == 1) {
+                    // If both layers are OVER layers
+                    // top layer's image
+                    $mainframe = '<img src="' . $this->borderTopLayer->imageUrl . '" class="avatar-border top" alt="' . $this->borderTopLayer->name . ' Avatar Frame">';
+                    // bottom layer's image
+                    $secondframe = '<img src="' . $this->borderBottomLayer->imageUrl . '" class="avatar-border" alt="' . $this->borderBottomLayer->name . ' Avatar Frame">';
                 } else {
-                    return $styling . $secondframe . $mainframe . $avatar . '</div>';
+                    // If one layer is UNDER and one is OVER
+                    $mainlayer = ($this->borderTopLayer->border_style == 0 ? 'under' : ' ');
+                    $secondlayer = ($this->borderBottomLayer->border_style == 0 ? 'under' : ' ');
+
+                    // top layer's image
+                    $mainframe = '<img src="' . $this->borderTopLayer->imageUrl . '" class="avatar-border ' . $mainlayer . '" alt="' . $this->borderTopLayer->name . ' Avatar Frame">';
+                    // bottom layer's image
+                    $secondframe = '<img src="' . $this->borderBottomLayer->imageUrl . '" class="avatar-border ' . $secondlayer . '" alt="' . $this->borderBottomLayer->name . ' Avatar Frame">';
                 }
+                return $styling . $avatar . $mainframe . $secondframe . '</div>';
             } elseif (isset($this->borderVariant)) {
-                $mainframe = '<img src="' . $this->borderVariant->imageUrl .
-                    '" style="position: absolute;width:' . $height . '; height:' . $height . ';">';
-                $borderstyle = $this->borderVariant;
+                $mainframe = '<img src="' . $this->borderVariant->imageUrl . '" class="avatar-border ' . $layer . '" alt="' . $this->borderVariant->name . ' ' . $this->border->name . ' Avatar Frame">';
             } else {
-                $mainframe = '<img src="' . $this->border->imageUrl .
-                    '" style="position: absolute;width:' . $height . '; height:' . $height . ';">';
-                $borderstyle = $this->border;
+                $mainframe = '<img src="' . $this->border->imageUrl . '" class="avatar-border '. $layer .'" alt="' . $this->border->name . ' Avatar Frame">';
             }
 
             if (!isset($this->borderBottomLayer) && !isset($this->borderTopLayer)) {
-                //under...
-                if ($borderstyle->border_style) {
-                    return $styling . $avatar . $mainframe . '</div>';
-                } else {
-                    return $styling . $mainframe . $avatar . '</div>';
-                }
+                return $styling . $avatar . $mainframe . '</div>';
             }
-
-            //if no border return standard avatar style
         }
-        return $styling . $avatar .
-            '
-        </div>';
+        //if no border return standard avatar style
+        return $styling . $avatar . '</div>';
     }
 
 }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -356,7 +356,7 @@ class UserService extends Service
                     }
                 }
                 if (!$border->is_active) {
-                    abort(404);
+                    throw new \Exception("This border is not active.");
                 }
                 if ($border->admin_only) {
                     throw new \Exception("You cannot select a staff border.");
@@ -376,7 +376,7 @@ class UserService extends Service
                         }
                     }
                     if (!$variant->is_active) {
-                        abort(404);
+                        throw new \Exception("This border variant is not active.");
                     }
                     if ($variant->parent->admin_only) {
                         throw new \Exception("You cannot select a staff border.");
@@ -384,30 +384,34 @@ class UserService extends Service
                 }
             }
             if (!$data['bottom_border_id'] && $data['top_border_id'] || $data['bottom_border_id'] && !$data['top_border_id']) {
-                abort(404);
+                throw new \Exception("You must select both a top border and a bottom border.");
             }
             if ($data['bottom_border_id'] > 0) {
                 $layer = Border::where('id', $data['bottom_border_id'])->whereNotNull('parent_id')->where('border_type', 'bottom')->first();
                 if (!$layer) {
-                    abort(404);
+                    throw new \Exception("That bottom border does not exist.");
                 }
                 $toplayer = Border::where('id', $data['top_border_id'])->whereNotNull('parent_id')->where('border_type', 'top')->first();
                 if (!$toplayer) {
-                    abort(404);
+                    throw new \Exception("That top border does not exist.");
                 }
                 //do some validation...
                 if (!Auth::user()->isStaff) {
-                    if (!$layer->parent->is_default) {
-                        if (!Auth::user()->hasBorder($layer->parent->id)) {
+                    if (!$layer->parent->is_default || !$toplayer->parent->is_default) {
+                        if (!Auth::user()->hasBorder($layer->parent->id) || !Auth::user()->hasBorder($toplayer->parent->id)) {
                             throw new \Exception("You do not own this border.");
                         }
                     }
                     if (!$layer->is_active) {
-                        abort(404);
+                        throw new \Exception("This bottom border is not active.");
                     }
-                    if ($layer->parent->admin_only) {
+                    if (!$toplayer->is_active) {
+                        throw new \Exception("This top border is not active.");
+                    }
+                    if ($layer->parent->admin_only || $toplayer->parent->admin_only) {
                         throw new \Exception("You cannot select a staff border.");
                     }
+
                 }
             }
 

--- a/public/css/lorekeeper.css
+++ b/public/css/lorekeeper.css
@@ -1,6 +1,6 @@
 /**************************************************************************************************
-    
-    Font definitions 
+
+    Font definitions
 
 **************************************************************************************************/
 
@@ -14,15 +14,15 @@
 }
 
 /**************************************************************************************************
-    
+
     Base styles
-    
+
 **************************************************************************************************/
 
 h1, h2, h3, h4, h5,
 .h1, .h2, .h3, .h4, .h5 {
     text-transform: uppercase;
-    font-family: Roboto Condensed, serif; 
+    font-family: Roboto Condensed, serif;
     font-weight: bold;
 }
 
@@ -46,15 +46,15 @@ a:hover {
 
 body {
     background-color: transparent;
-    font-family: Lato, sans-serif; 
+    font-family: Lato, sans-serif;
     min-height: 100vh;
     font-size: 80%;
 }
 
 /**************************************************************************************************
-    
+
     Helpers
-    
+
 **************************************************************************************************/
 
 .hide {
@@ -67,9 +67,9 @@ body {
 }
 
 /**************************************************************************************************
-    
+
     Layout
-    
+
 **************************************************************************************************/
 
 #app {
@@ -105,7 +105,7 @@ main > .row {
 
 .navbar .navbar-brand, .navbar .nav-item {
     text-transform: uppercase;
-    font-family: Roboto Condensed, serif; 
+    font-family: Roboto Condensed, serif;
 }
 
 .navbar .row { width: 100%; }
@@ -129,14 +129,14 @@ main > .row {
     border-bottom-left-radius: .25rem;
     margin-bottom: 1em;
     padding: 0.4em 0;
-    
+
     box-shadow: 0px 0px 6px 3px rgba(0,0,0,0.1);
 }
 
 .sidebar .sidebar-header,
 .sidebar .sidebar-section .sidebar-section-header {
     text-transform: uppercase;
-    font-family: Roboto Condensed, serif; 
+    font-family: Roboto Condensed, serif;
     font-weight: bold;
 }
 
@@ -186,7 +186,7 @@ main > .row {
 	.site-mobile-header {
 		top: 54px !important;
     }
-    
+
     .timestamp {
 		margin-left: 1rem!important;
 		margin-right: 1rem!important;
@@ -234,7 +234,7 @@ main > .row {
     }
     .sidebar.active {
         left: 0%;
-    } 
+    }
 
     .sidebar > ul {
         padding-top: 0px;
@@ -252,19 +252,19 @@ main > .row {
         border-radius: 0;
         margin-bottom: 1em;
         padding: 0.4em 0;
-        
+
         box-shadow: none;
     }
-	
+
 	/*fix for screen being over-wide on mobile*/
 	.row {
 		margin:0; max-width:100%;
 	}
-    
+
 	.container-fluid {
 		padding:0px;
 	}
-    
+
 	.site-footer .navbar .navbar-nav {
 		flex-wrap: wrap; justify-content: center;
 	}
@@ -297,9 +297,9 @@ main > .row {
 }
 
 /**************************************************************************************************
-    
+
     Content
-    
+
 **************************************************************************************************/
 .modal-header {
     border-bottom: 0px;
@@ -309,7 +309,7 @@ main > .row {
 }
 
 .tooltip-inner {
-    max-width: 350px !important; 
+    max-width: 350px !important;
 }
 
 .nav-tabs .nav-link.active {
@@ -629,16 +629,57 @@ tr.accountbound {
         padding-left: 3rem;
         border-left-width: 2px!important;
     }
-    
+
 @media only screen and (max-width: 600px) {
     .comment_replies { padding-left:1rem;}
-}
-
-.avatar {
-    border: 16px solid rgba(0, 0, 0, .0); 
 }
 
 .image-info-box {
     overflow-y: auto;
       max-height: 60vh;
   }
+
+[id^="comment"] .user-avatar {
+    margin-right: 0.25rem;
+}
+
+  /* USER BORDERS *****************************************************************************************/
+
+.user-avatar {
+    position: relative;
+    margin: auto;
+    max-width: 150px;
+    z-index: 0;
+}
+
+@media (max-width: 991px) {
+    .user-avatar {
+        max-width: 125px;
+    }
+}
+
+.user-avatar .avatar {
+    aspect-ratio: 1 / 1;
+    border: 15px solid transparent;
+    border-radius: 50%;
+    max-width: 100%;
+}
+
+.user-avatar .avatar-border {
+    max-width: 100%;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+}
+
+.avatar-border.top {
+    z-index: 1;
+}
+
+.avatar-border.under {
+    z-index: -1;
+}
+
+.avatar-border.bottom {
+    z-index: -2;
+}

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -132,7 +132,8 @@
         <h3 class="text-center">Your Borders</h3>
         <div class="card p-3 mb-2 image-info-box">
             @if ($default->count())
-                <h4>Default</h4>
+                <h4 class="mb-0">Default</h4>
+                <hr class="mt-0">
                 <div class="row">
                     @foreach ($default as $border)
                         <div class="col-md-3 col-6 text-center">
@@ -147,7 +148,8 @@
                 </div>
             @endif
             @if (Auth::user()->borders->count())
-                <h4>Unlocked</h4>
+                <h4 class="mb-0">Unlocked</h4>
+                <hr class="mt-0">
                 <div class="row">
                     @foreach (Auth::user()->borders as $border)
                         <div class="col-md-3 col-6 text-center">
@@ -163,7 +165,8 @@
             @endif
             @if (Auth::user()->isStaff)
                 @if ($admin->count())
-                    <h4>Staff-Only</h4>
+                    <h4 class="mb-0">Staff-Only</h4>
+                    <hr class="mt-0">
                     <small>You can see these as a member of staff</small>
                     <div class="row">
                         @foreach ($admin as $border)

--- a/resources/views/admin/borders/_create_edit_border_variant.blade.php
+++ b/resources/views/admin/borders/_create_edit_border_variant.blade.php
@@ -1,21 +1,19 @@
 {!! Form::open(['url' => 'admin/data/borders/edit/' . $border->id . '/' . $type . 's/' . ($variant->id ? 'edit/' . $variant->id : 'create'), 'files' => true]) !!}
 
+@php
+    $word = $type == 'variant' ? 'Variant' : (($type == 'top') ? 'Top Layer' : 'Bottom Layer')
+@endphp
+
 <h3>Basic Information</h3>
 
 <div class="row">
     <div class="col-md-6 form-group">
-        {!! Form::label('Name') !!}
+        {!! Form::label('name', $word . ' Name', ['class' => 'font-weight-bold']) !!}
         {!! Form::text('name', $variant->name, ['class' => 'form-control']) !!}
     </div>
-    @if ($variant->id)
-        <div class="col-md-6 form-group">
-            {!! Form::checkbox('delete', 1, false, [
-                'class' => 'form-check-input',
-                'data-toggle' => 'toggle',
-            ]) !!}
-            {!! Form::label('delete', 'Delete Variant', ['class' => 'form-check-label ml-3']) !!}
-        </div>
-    @endif
+</div>
+
+<div class="row">
     <div class="col-md-6 form-group">
         {!! Form::checkbox('is_active', 1, $variant->is_active, [
             'class' => 'form-check-input',
@@ -23,6 +21,15 @@
         ]) !!}
         {!! Form::label('is_active', 'Active?', ['class' => 'form-check-label ml-3']) !!} {!! add_help('Users can\'t see or select this border if it isn\'t visible.') !!}
     </div>
+    @if ($variant->id)
+        <div class="col-md-6 form-group">
+            {!! Form::checkbox('delete', 1, false, [
+                'class' => 'form-check-input',
+                'data-toggle' => 'toggle',
+            ]) !!}
+            {!! Form::label('delete', 'Delete ' . $word , ['class' => 'form-check-label ml-3']) !!}
+        </div>
+    @endif
 </div>
 
 <div class="row">
@@ -43,27 +50,36 @@
     </div>
 </div>
 
-<h3>Image</h3>
-<p>An image is required. You can't have a border with no image!</p>
+<hr>
 
 <div class="row">
     @if ($variant->id)
-        <div class="col-md-2">
-            <div class="form-group">
-                <h5>Image</h5>
-                <img src="{{ $variant->imageUrl }}" class="mw-100" style="width:125px; height:125px;" />
-                <br>
-            </div>
-            <div class="form-group">
-                <h5>In Action</h5>
-                {!! $variant->preview() !!}
-                <br>
+        <div class="col-md-4 text-center">
+            <h3>Preview</h3>
+            <div class="row no-gutters">
+                <div class="col-6 col-md-12">
+                    <div class="form-group">
+                        <h5>Image</h5>
+                        <div class="user-avatar">
+                            <img src="{{ $variant->imageUrl }}" class="img-fluid" />
+                        </div>
+                    </div>
+                </div>
+                <div class="col-6 col-md-12">
+                    <div class="form-group">
+                        <h5>In Action</h5>
+                        {!! $variant->preview() !!}
+                    </div>
+                </div>
             </div>
         </div>
     @endif
-    <div class="col-md-6">
+    <div class="col-md-7">
+        <h3>Image</h3>
+        <p>An image is required. You can't have a border with no image!</p>
+
         <div class="form-group">
-            {!! Form::label('Variant Image') !!}
+            {!! Form::label($word . ' Image') !!}
             <div>{!! Form::file('image') !!}</div>
             <div class="text-muted">Supports .png and .gif</div>
         </div>
@@ -76,6 +92,7 @@
         </div>
     </div>
 </div>
+
 <div class="text-right">
     {!! Form::submit($variant->id ? 'Edit' : 'Create', ['class' => 'btn btn-primary']) !!}
 </div>

--- a/resources/views/admin/borders/create_edit_border.blade.php
+++ b/resources/views/admin/borders/create_edit_border.blade.php
@@ -11,7 +11,8 @@
         ($border->id ? 'Edit' : 'Create') . ' Border' => $border->id ? 'admin/data/borders/edit/' . $border->id : 'admin/data/borders/create',
     ]) !!}
 
-    <h1>{{ $border->id ? 'Edit' : 'Create' }} Border
+    <h1>
+        {{ $border->id ? 'Edit' : 'Create' }} Border
         @if ($border->id)
             <a href="#" class="btn btn-outline-danger float-right delete-border-button">Delete Border</a>
         @endif
@@ -39,42 +40,51 @@
         </div>
     </div>
 
-    <h3>Image</h3>
-    <p>An image is required. You can't have a border with no image!</p>
-
     <div class="row">
         @if ($border->id)
-            <div class="col-md-2">
-                <div class="form-group">
-                    <h5>Image</h5>
-                    <img src="{{ $border->imageUrl }}" class="mw-100" style="width:125px; height:125px;" />
-                    <br>
-                </div>
-                <div class="form-group">
-                    <h5>In Action</h5>
-                    {!! $border->preview() !!}
-                    <br>
+            <div class="col-md-3 text-center">
+                <h3>Preview</h3>
+                <div class="row no-gutters">
+                    <div class="col-6 col-md-12">
+                        <div class="form-group">
+                            <h5>Border Image</h5>
+                            <div class="user-avatar">
+                                <img src="{{ $border->imageUrl }}" class="img-fluid" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-6 col-md-12">
+                        <div class="form-group">
+                            <h5>In Action</h5>
+                            {!! $border->preview() !!}
+                        </div>
+                    </div>
                 </div>
             </div>
         @endif
+
         <div class="col-md-6">
+            <h3>Image</h3>
+            <p><b>An image is required. You can't have a border with no image!</b> A square canvas is recommended. The container that contains the avatar and borders has a max-width set of 150px, while the avatar itself is resized down to around 120px. This can be adjusted in the CSS.</p>
+
             <div class="form-group">
-                {!! Form::label('Border Image') !!}
+                {!! Form::label('image', 'Border Image', ['class' => 'font-weight-bold']) !!}
                 <div>{!! Form::file('image') !!}</div>
                 <div class="text-muted">Supports .png and .gif</div>
             </div>
             <div class="form-group">
                 {!! Form::label('Border Style (Required)') !!}{!! add_help('Choose how the border will display around an icon. It can display over or under the user\'s icon.') !!}
                 {!! Form::select('border_style', ['0' => 'Under', '1' => 'Over'], $border->border_style, [
-                    'class' => 'form-control',
+                    'class' => 'form-control w-75',
                     'placeholder' => 'Select a Type',
                 ]) !!}
             </div>
         </div>
-    </div>
-    <br>
-    <div class="row">
+
         <div class="col-md-3">
+            <h3>Border Options</h3>
+            <p>You can adjust whether your border is active (visible), allowed for free use by all users, or if it is exclusive to staff.</p>
+
             <div class="form-group">
                 {!! Form::checkbox('is_default', 1, $border->is_default, [
                     'class' => 'form-check-input',
@@ -82,8 +92,6 @@
                 ]) !!}
                 {!! Form::label('is_default', 'Default Border', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If enabled, this border will be automatically available for any users.') !!}
             </div>
-        </div>
-        <div class="col-md-3">
             <div class="form-group">
                 {!! Form::checkbox('is_active', 1, $border->is_active, [
                     'class' => 'form-check-input',
@@ -91,8 +99,6 @@
                 ]) !!}
                 {!! Form::label('is_active', 'Active?', ['class' => 'form-check-label ml-3']) !!} {!! add_help('Users can\'t see or select this border if it isn\'t visible.') !!}
             </div>
-        </div>
-        <div class="col-md-3">
             <div class="form-group">
                 {!! Form::checkbox('admin_only', 1, $border->admin_only, [
                     'class' => 'form-check-input',
@@ -141,17 +147,16 @@
             <div class="card border-0">
                 <div class="card-body">
                     <h2 class="text-center">Top Layers</h2>
-                    <div class="text-right">
+                    <div class="text-right mb-2">
                         <a href="#" class="btn btn-primary" id="add-top">Add Top Layer</a>
                     </div>
                     @if ($border->topLayers->count())
                         <div class="row">
                             @foreach ($border->topLayers as $layer)
                                 <div class="col-md-3 col-6 text-center">
-                                    <div class="shop-image">
-                                        {!! $layer->preview() !!}
-                                    </div>
-                                    <div class="shop-name mt-1 text-center">
+                                    {!! $layer->preview() !!}
+
+                                    <div class="text-center">
                                         <h5>{!! $layer->name !!}</h5>
                                         <a href="#" class="btn btn-sm btn-primary edit-top" data-id="{{ $layer->id }}"><i class="fas fa-cog mr-1"></i>Edit</a>
                                     </div>
@@ -161,18 +166,18 @@
                     @else
                         <div class="alert alert-info">No top layers found.</div>
                     @endif
+                    <hr class="w-75">
                     <h2 class="text-center">Bottom Layers</h2>
-                    <div class="text-right">
+                    <div class="text-right mb-2">
                         <a href="#" class="btn btn-primary" id="add-bottom">Add Bottom Layer</a>
                     </div>
                     @if ($border->bottomLayers->count())
                         <div class="row">
                             @foreach ($border->bottomLayers as $layer)
                                 <div class="col-md-3 col-6 text-center">
-                                    <div class="shop-image">
-                                        {!! $layer->preview() !!}
-                                    </div>
-                                    <div class="shop-name mt-1 text-center">
+                                    {!! $layer->preview() !!}
+
+                                    <div class="text-center">
                                         <h5>{!! $layer->name !!}</h5>
                                         <a href="#" class="btn btn-sm btn-primary edit-bottom" data-id="{{ $layer->id }}"><i class="fas fa-cog mr-1"></i>Edit</a>
                                     </div>
@@ -191,17 +196,16 @@
             <p>These are the variations for this border. A user that owns this base border can switch between its variants for free.</p>
             <div class="card border-0">
                 <div class="card-body">
-                    <div class="text-right">
+                    <div class="text-right mb-2">
                         <a href="#" class="btn btn-primary" id="add-variant">Add Variant</a>
                     </div>
                     @if ($border->variants->count())
                         <div class="row">
                             @foreach ($border->variants as $variant)
                                 <div class="col-md-3 col-6 text-center">
-                                    <div class="shop-image">
-                                        {!! $variant->preview() !!}
-                                    </div>
-                                    <div class="shop-name mt-1 text-center">
+                                    {!! $variant->preview() !!}
+
+                                    <div class="text-center">
                                         <h5>{!! $variant->name !!}</h5>
                                         <a href="#" class="btn btn-sm btn-primary edit-variant" data-id="{{ $variant->id }}"><i class="fas fa-cog mr-1"></i>Edit</a>
                                     </div>
@@ -214,6 +218,7 @@
                 </div>
             </div>
         </div>
+
         <h3>Preview</h3>
         <div class="card mb-3">
             <div class="card-body">

--- a/resources/views/world/_border_entry.blade.php
+++ b/resources/views/world/_border_entry.blade.php
@@ -1,11 +1,22 @@
 <div class="row world-entry">
-
-    <div class="col-md-3 world-entry-image"><a href="{{ $border->imageUrl }}" data-lightbox="entry" data-title="{{ $border->name }}"><img src="{{ $border->imageUrl }}" class="world-entry-image" alt="{{ $border->name }}" /></a>
-        <div id="test-{{ $border->id }}">
-            {!! $border->preview(Auth::check() ? Auth::user()->id : '') !!}
+    <div class="col-md-3 world-entry-image">
+        <div class="row no-gutters">
+            <div class="col-6 col-md-12">
+                <div class="user-avatar">
+                    <a href="{{ $border->imageUrl }}" data-lightbox="entry" data-title="{{ $border->name }}" class=>
+                        <img src="{{ $border->imageUrl }}" class="world-entry-image" alt="{{ $border->name }}" />
+                    </a>
+                </div>
+            </div>
+            <hr class="w-75 d-none d-md-block">
+            <div class="col-6 col-md-12">
+                <div id="test-{{ $border->id }}">
+                    {!! $border->preview(Auth::check() ? Auth::user()->id : '') !!}
+                </div>
+            </div>
         </div>
         @if ($border->topLayers->count() && $border->bottomLayers->count())
-            <hr class="w-75" />
+            <hr class="w-75">
             <h5>Layer Preview</h5>
             <div class="form-group">
                 {!! Form::label('Top Layer') !!}
@@ -17,6 +28,7 @@
             </div>
         @endif
     </div>
+
     <div class="{{ $border->imageUrl ? 'col-md-9' : 'col-12' }}">
         <h3>
             {!! $border->displayName !!}@if (isset($border->idUrl) && $border->idUrl)
@@ -84,13 +96,13 @@
 @if ($border->topLayers->count() && $border->bottomLayers->count())
     <script>
         $('#top-{{ $border->id }}').change(function() {
-            refreshBorder();
+            refreshBorder{{ $border->id }}();
         });
         $('#bottom-{{ $border->id }}').change(function() {
-            refreshBorder();
+            refreshBorder{{ $border->id }}();
         });
 
-        function refreshBorder() {
+        function refreshBorder{{ $border->id }}() {
             var top = $('#top-{{ $border->id }}').val();
             var bottom = $('#bottom-{{ $border->id }}').val();
             var border = {{ $border->id }};

--- a/resources/views/world/_border_page.blade.php
+++ b/resources/views/world/_border_page.blade.php
@@ -19,7 +19,7 @@
     {!! breadcrumbs(['World' => 'world', 'User Borders' => 'world/borders', $border->name => $border->idUrl]) !!}
 
     <div class="card mb-3">
-        <div class="card-body">
+        <div class="card-body p-2 p-md-3">
             @include('world._border_entry', [
                 'imageUrl' => $border->imageUrl,
                 'name' => $border->displayName,

--- a/resources/views/world/borders.blade.php
+++ b/resources/views/world/borders.blade.php
@@ -51,7 +51,7 @@
     {!! $borders->render() !!}
     @foreach ($borders as $border)
         <div class="card mb-3">
-            <div class="card-body">
+            <div class="card-body p-2 p-md-3">
                 @include('world._border_entry', ['border' => $border])
             </div>
         </div>


### PR DESCRIPTION
A bunch of fixes and tweaks for the user borders extension. This will make user borders responsive.

A general gist of changes:
- Redid all the code surrounding user avatar and border previews being displayed. They now assign specific CSS classes based on what they are (avatar, border, top layer, bottom layer, etc) which will also make it easier for site owners to edit them, as they will only need to change CSS, rather than going into the model.
- Order of avatar and frames within the parent container no longer matters; when a top & bottom layer are applied, the model will also determine which layer is the top and which layer is the bottom and assign classes accordingly, which will control how they are stacked.
- Avatars & borders are now responsive. It might look weird if you stick them in like a...50px container, considering that's _very_ tiny, but it's also very unlikely anyone will do that, so...
- Adds alt text to user avatars as well as all applied borders.
- Fixes the issue where only the last layered border on the world border index could be previewed. They will all preview fine, now.
- Fixes the error 500 page users will encounter if they only select one top layer or one bottom layer without selecting both, and will display an error message alerting them that they need to select both. While I was at it I added in a couple other validation error exception messages.
- Layout changes to the admin panel for borders as well as the world entries. Now the admin panel border page, top/bottom/variant modals, and the world entries will show the border and the preview side-by-side on smaller screens, which is nicer for comparison than having them stacked on top of each other.
- Small QOL change where the top/bottom/variant modals in the admin panel will actually say the name of the type you're creating/editing ("Variant", "Top Layer", "Bottom Layer") instead of all of them just saying "Variant".
- Other small little UI changes mostly in regards to padding and margins.