### PR TITLE
fix: change/simplify algorithm used for rolling encounter area

### DIFF
--- a/app/Models/Encounter/EncounterArea.php
+++ b/app/Models/Encounter/EncounterArea.php
@@ -165,32 +165,15 @@ class EncounterArea extends Model
      */
     public function roll($quantity = 1)
     {
-        $encounters = $this->encounters;
-        $totalWeight = 0;
-        foreach ($encounters as $encounter) {
-            $totalWeight += $encounter->weight;
-        }
+        $encounters = $this->encounters->pluck('weight','id')->toArray();
+        $rand = mt_rand(1, (int) array_sum($encounters));
 
-        for ($i = 0; $i < $quantity; $i++) {
-            $roll = mt_rand(0, $totalWeight - 1);
-            $result = null;
-            $prev = null;
-            $count = 0;
-            foreach ($encounters as $l) {
-                $count += $encounter->weight;
-
-                if ($roll < $count) {
-                    $result = $l;
-                    break;
-                }
-                $prev = $l;
-            }
-            if (!$result) {
-                $result = $prev;
+        foreach ($encounters as $key => $value) {
+            $rand -= $value;
+            if ($rand <= 0) {
+                return AreaEncounters::find($key);
             }
         }
-
-        return $result;
     }
 
     /**********************************************************************************************


### PR DESCRIPTION
Change algorithm to the one used here (my tried & true when it comes to weighted random): https://stackoverflow.com/a/11872928

Fixes the "reversed" percentage known bug with Encounter Areas.