### PR TITLE
Queue Creator Feature Additions

### DIFF
--- a/app/Http/Controllers/Admin/Data/QueueController.php
+++ b/app/Http/Controllers/Admin/Data/QueueController.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Item\Item;
 use App\Models\Queue\Queue;
 use App\Models\Queue\QueueCategory;
+use App\Models\Rank\Rank;
 use App\Services\QueueService;
 use Config;
 use Illuminate\Http\Request;
@@ -199,6 +200,7 @@ class QueueController extends Controller
             'categories'    => ['none' => 'No category'] + QueueCategory::orderBy('sort', 'DESC')->pluck('name', 'id')->toArray(),
             'types'         => $result,
             'limit_periods' => [null => 'None', 'Hour' => 'Hour', 'Day' => 'Day', 'Week' => 'Week', 'Month' => 'Month', 'Year' => 'Year'],
+            'ranks'         => ['none' => 'All Staff with Submissions Power'] + Rank::pluck('name', 'id')->toArray(),
         ]);
     }
 
@@ -227,6 +229,7 @@ class QueueController extends Controller
             'types'         => $result,
             'item_limits'   => $queue->configSet('item_consume') ? Item::orderBy('name')->pluck('name', 'id') : [],
             'limit_periods' => [null => 'None', 'Hour' => 'Hour', 'Day' => 'Day', 'Week' => 'Week', 'Month' => 'Month', 'Year' => 'Year'],
+            'ranks'         => Rank::pluck('name', 'id')->toArray(),
         ] + $queue->service->getEditData());
     }
 
@@ -241,8 +244,7 @@ class QueueController extends Controller
     public function postCreateEditQueue(Request $request, QueueService $service, $id = null)
     {
         $id ? $request->validate(Queue::$updateRules) : $request->validate(Queue::$createRules);
-        $data = $request->only([
-            'name', 'queue_category_id', 'summary', 'description', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'is_active', 'image', 'remove_image', 'prefix', 'hide_submissions', 'staff_only', 'form', 'queue_type', 'limit', 'limit_period', 'check_text', 'user_rewardable_type', 'user_rewardable_id', 'user_quantity', 'character_rewardable_type', 'character_rewardable_id', 'character_quantity', 'limit_concurrent'
+        $data = $request->only(['name', 'queue_category_id', 'staff_rank_id', 'summary', 'description', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'is_active', 'image', 'remove_image', 'prefix', 'hide_submissions', 'staff_only', 'form', 'queue_type', 'limit', 'limit_period', 'check_text', 'user_rewardable_type', 'user_rewardable_id', 'user_quantity', 'character_rewardable_type', 'character_rewardable_id', 'character_quantity', 'limit_concurrent'
         ]);
         if ($id && $service->updateQueue(Queue::find($id), $data, Auth::user())) {
             flash('Queue updated successfully.')->success();

--- a/app/Http/Controllers/Admin/HomeController.php
+++ b/app/Http/Controllers/Admin/HomeController.php
@@ -45,7 +45,7 @@ class HomeController extends Controller
             'gallerySubmissionCount' => GallerySubmission::collaboratorApproved()->where('status', 'Pending')->count(),
             'galleryAwardCount' => GallerySubmission::requiresAward()->where('is_valued', 0)->count(),
             'queueCount'        => QueueSubmission::where('status', 'Pending')->whereNotNull('queue_id')->count(),
-            'queues'            => Queue::get(),
+            'queues'            => Queue::query()->active()->get(),
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/HomeController.php
+++ b/app/Http/Controllers/Admin/HomeController.php
@@ -15,6 +15,7 @@ use App\Models\Trade;
 use App\Models\Report\Report;
 
 use App\Http\Controllers\Controller;
+use App\Models\Queue\Queue;
 use App\Models\Queue\QueueSubmission;
 
 class HomeController extends Controller
@@ -44,6 +45,7 @@ class HomeController extends Controller
             'gallerySubmissionCount' => GallerySubmission::collaboratorApproved()->where('status', 'Pending')->count(),
             'galleryAwardCount' => GallerySubmission::requiresAward()->where('is_valued', 0)->count(),
             'queueCount'        => QueueSubmission::where('status', 'Pending')->whereNotNull('queue_id')->count(),
+            'queues'            => Queue::get(),
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/QueueSubmissionController.php
+++ b/app/Http/Controllers/Admin/QueueSubmissionController.php
@@ -7,6 +7,7 @@ use App\Models\Character\Character;
 use App\Models\Currency\Currency;
 use App\Models\Item\Item;
 use App\Models\Loot\LootTable;
+use App\Models\Queue\Queue;
 use App\Models\Queue\QueueCategory;
 use App\Models\Raffle\Raffle;
 use App\Models\Queue\QueueSubmission;
@@ -47,6 +48,36 @@ class QueueSubmissionController extends Controller {
         return view('admin.queues.submission_index', [
             'submissions' => $submissions->paginate(30)->appends($request->query()),
             'categories'  => ['none' => 'Any Category'] + QueueCategory::orderBy('sort', 'DESC')->pluck('name', 'id')->toArray(),
+        ]);
+    }
+
+    /**
+     * Shows a specific queue's submission index page.
+     *
+     * @param string $status
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getQueueSubmissionIndex(Request $request, $id, $status = null) {
+
+        $submissions = QueueSubmission::with('queue')->where('queue_id', $id)->where('status', $status ? ucfirst($status) : 'Pending');
+        $data = $request->only(['sort']);
+        if (isset($data['sort'])) {
+            switch ($data['sort']) {
+                case 'newest':
+                    $submissions->sortNewest();
+                    break;
+                case 'oldest':
+                    $submissions->sortOldest();
+                    break;
+            }
+        } else {
+            $submissions->sortOldest();
+        }
+
+        return view('admin.queues.submission_index', [
+            'queue' => Queue::find($id),
+            'submissions' => $submissions->paginate(30)->appends($request->query()),
         ]);
     }
 

--- a/app/Http/Controllers/Admin/QueueSubmissionController.php
+++ b/app/Http/Controllers/Admin/QueueSubmissionController.php
@@ -60,6 +60,9 @@ class QueueSubmissionController extends Controller {
      */
     public function getQueueSubmissionIndex(Request $request, $id, $status = null) {
 
+        $queue = Queue::find($id);
+        if ($queue->staff_rank_id && !in_array(Auth::user()->rank_id, $queue->staff_rank_id)) abort(404);
+        
         $submissions = QueueSubmission::with('queue')->where('queue_id', $id)->where('status', $status ? ucfirst($status) : 'Pending');
         $data = $request->only(['sort']);
         if (isset($data['sort'])) {
@@ -76,7 +79,7 @@ class QueueSubmissionController extends Controller {
         }
 
         return view('admin.queues.submission_index', [
-            'queue' => Queue::find($id),
+            'queue' => $queue,
             'submissions' => $submissions->paginate(30)->appends($request->query()),
         ]);
     }

--- a/app/Http/Controllers/Users/QueueSubmissionController.php
+++ b/app/Http/Controllers/Users/QueueSubmissionController.php
@@ -37,7 +37,7 @@ class QueueSubmissionController extends Controller
      *
      * @return \Illuminate\Contracts\Support\Renderable
      */
-    public function getIndex(Request $request)
+    public function getIndex(Request $request, $id = null)
     {
         $submissions = QueueSubmission::with('queue')->where('user_id', Auth::user()->id)->whereNotNull('queue_id');
         $type        = $request->get('type');
@@ -45,10 +45,14 @@ class QueueSubmissionController extends Controller
             $type = 'Pending';
         }
 
+        if (isset($id))
+            $submissions = $submissions->where('queue_id', $id);
+
         $submissions = $submissions->where('status', ucfirst($type));
 
         return view('home.queues.submissions', [
             'submissions' => $submissions->orderBy('id', 'DESC')->paginate(20)->appends($request->query()),
+            'queue' => isset($id) ? Queue::find($id) : NULL,
             'isClaims'    => false,
         ]);
     }

--- a/app/Http/Controllers/Users/QueueSubmissionController.php
+++ b/app/Http/Controllers/Users/QueueSubmissionController.php
@@ -39,12 +39,16 @@ class QueueSubmissionController extends Controller
      */
     public function getIndex(Request $request, $id = null)
     {
-        $submissions = QueueSubmission::with('queue')->where('user_id', Auth::user()->id)->whereNotNull('queue_id');
+        $submissions = QueueSubmission::with('queue')->where('user_id', Auth::user()->id)->whereNotNull('queue_id')->whereHas('queue', function ($query) {
+            return $query->active();
+        });
         $type        = $request->get('type');
         if (! $type) {
             $type = 'Pending';
         }
 
+        $queue = Queue::find($id);
+        if (isset($queue) && !$queue->is_active) abort(404);
         if (isset($id))
             $submissions = $submissions->where('queue_id', $id);
 
@@ -52,7 +56,7 @@ class QueueSubmissionController extends Controller
 
         return view('home.queues.submissions', [
             'submissions' => $submissions->orderBy('id', 'DESC')->paginate(20)->appends($request->query()),
-            'queue' => isset($id) ? Queue::find($id) : NULL,
+            'queue' => $queue,
             'isClaims'    => false,
         ]);
     }

--- a/app/Models/Queue/Queue.php
+++ b/app/Models/Queue/Queue.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Models\Queue;
 
 use App\Models\Item\Item;
@@ -6,8 +7,7 @@ use App\Models\Model;
 use App\Services\Queue\GeneralService;
 use Carbon\Carbon;
 
-class Queue extends Model
-{
+class Queue extends Model {
     /**
      * The attributes that are mass assignable.
      *
@@ -17,6 +17,7 @@ class Queue extends Model
         'queue_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active',
         'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 'prefix',
         'hide_submissions', 'staff_only', 'hash', 'form', 'parsed_form', 'queue_type', 'data', 'checklist', 'limit', 'limit_period', 'output', 'limit_concurrent',
+        'staff_rank_id'
     ];
 
     /**
@@ -71,29 +72,30 @@ class Queue extends Model
 
         RELATIONS
 
-    **********************************************************************************************/
+     **********************************************************************************************/
 
     /**
      * Get the category the queue belongs to.
      */
-    public function category()
-    {
+    public function category() {
         return $this->belongsTo(QueueCategory::class, 'queue_category_id');
     }
 
     /**
      * Get the submissions that belong to this queue.
      */
-    public function submissions()
-    {
-        return $this->hasMany(QueueSubmission::class, 'queue_id');
+    public function submissions($status) {
+        if (isset($status))
+            return $this->hasMany(QueueSubmission::class, 'queue_id')->where('status', ucfirst($status));
+        else
+            return $this->hasMany(QueueSubmission::class, 'queue_id');
     }
 
     /**********************************************************************************************
 
         SCOPES
 
-    **********************************************************************************************/
+     **********************************************************************************************/
 
     /**
      * Scope a query to only include active queues.
@@ -102,8 +104,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeActive($query)
-    {
+    public function scopeActive($query) {
         return $query->where('is_active', 1)
             ->where(function ($query) {
                 $query->whereNull('start_at')->orWhere('start_at', '<', Carbon::now())->orWhere(function ($query) {
@@ -124,8 +125,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeOpen($query, $isOpen)
-    {
+    public function scopeOpen($query, $isOpen) {
         if ($isOpen) {
             $query->where(function ($query) {
                 $query->whereNull('end_at')->where('start_at', '<', Carbon::now());
@@ -153,8 +153,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeStaffOnly($query, $user)
-    {
+    public function scopeStaffOnly($query, $user) {
         if ($user && $user->isStaff) {
             return $query;
         }
@@ -170,8 +169,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeSortAlphabetical($query, $reverse = false)
-    {
+    public function scopeSortAlphabetical($query, $reverse = false) {
         return $query->orderBy('name', $reverse ? 'DESC' : 'ASC');
     }
 
@@ -182,8 +180,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeSortCategory($query)
-    {
+    public function scopeSortCategory($query) {
         if (QueueCategory::all()->count()) {
             return $query->orderBy(QueueCategory::select('sort')->whereColumn('queues.queue_category_id', 'queue_categories.id'), 'DESC');
         }
@@ -198,8 +195,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeSortNewest($query)
-    {
+    public function scopeSortNewest($query) {
         return $query->orderBy('id', 'DESC');
     }
 
@@ -210,8 +206,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeSortOldest($query)
-    {
+    public function scopeSortOldest($query) {
         return $query->orderBy('id');
     }
 
@@ -223,8 +218,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeSortStart($query, $reverse = false)
-    {
+    public function scopeSortStart($query, $reverse = false) {
         return $query->orderBy('start_at', $reverse ? 'DESC' : 'ASC');
     }
 
@@ -236,8 +230,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeSortEnd($query, $reverse = false)
-    {
+    public function scopeSortEnd($query, $reverse = false) {
         return $query->orderBy('end_at', $reverse ? 'DESC' : 'ASC');
     }
 
@@ -249,8 +242,7 @@ class Queue extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeSplash($query)
-    {
+    public function scopeSplash($query) {
         $query->whereHas('category', function ($query) {
             $query->where('key', null);
         })->orWhere('queue_category_id', null);
@@ -260,15 +252,14 @@ class Queue extends Model
 
         ACCESSORS
 
-    **********************************************************************************************/
+     **********************************************************************************************/
 
     /**
      * Displays the model's name, linked to its encyclopedia page.
      *
      * @return string
      */
-    public function getDisplayNameAttribute()
-    {
+    public function getDisplayNameAttribute() {
         return '<a href="' . $this->url . '" class="display-queue">' . $this->name . '</a>';
     }
 
@@ -277,8 +268,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getImageDirectoryAttribute()
-    {
+    public function getImageDirectoryAttribute() {
         return 'images/data/queues';
     }
 
@@ -287,8 +277,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getImageFileNameAttribute()
-    {
+    public function getImageFileNameAttribute() {
         return $this->id . '-' . $this->hash . '-image.png';
     }
 
@@ -297,8 +286,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getImagePathAttribute()
-    {
+    public function getImagePathAttribute() {
         return public_path($this->imageDirectory);
     }
 
@@ -307,9 +295,8 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getImageUrlAttribute()
-    {
-        if (! $this->has_image) {
+    public function getImageUrlAttribute() {
+        if (!$this->has_image) {
             return null;
         }
 
@@ -321,8 +308,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getUrlAttribute()
-    {
+    public function getUrlAttribute() {
         return url('queues/queues?name=' . $this->name);
     }
 
@@ -331,8 +317,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getIdUrlAttribute()
-    {
+    public function getIdUrlAttribute() {
         return url('queues/' . $this->id);
     }
 
@@ -341,8 +326,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getAssetTypeAttribute()
-    {
+    public function getAssetTypeAttribute() {
         return 'queues';
     }
 
@@ -351,8 +335,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getAdminUrlAttribute()
-    {
+    public function getAdminUrlAttribute() {
         return url('admin/data/queues/edit/' . $this->id);
     }
 
@@ -361,8 +344,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getAdminPowerAttribute()
-    {
+    public function getAdminPowerAttribute() {
         return 'edit_data';
     }
 
@@ -371,8 +353,7 @@ class Queue extends Model
      *
      * @return mixed
      */
-    public function getServiceAttribute()
-    {
+    public function getServiceAttribute() {
         $class = 'App\Services\Queue\\' . str_replace(' ', '', ucwords(str_replace('_', ' ', $this->queue_type))) . 'Service';
         return (new $class());
     }
@@ -382,8 +363,7 @@ class Queue extends Model
      *
      * @return mixed
      */
-    public function getConfigInfoAttribute()
-    {
+    public function getConfigInfoAttribute() {
         return config('lorekeeper.queue_types.' . $this->queue_type);
     }
 
@@ -392,8 +372,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getCustomImageDirectoryAttribute()
-    {
+    public function getCustomImageDirectoryAttribute() {
         return 'images/data/queues/images';
     }
 
@@ -402,8 +381,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function customImageFileName($key)
-    {
+    public function customImageFileName($key) {
         return $this->id . '-' . $key . '.png';
     }
 
@@ -412,8 +390,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function getCustomImagePathAttribute()
-    {
+    public function getCustomImagePathAttribute() {
         return public_path($this->customImageDirectory);
     }
 
@@ -422,8 +399,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function customImageUrl($key)
-    {
+    public function customImageUrl($key) {
         return asset($this->customImageDirectory . '/' . $this->CustomImageFileName($key));
     }
 
@@ -432,8 +408,7 @@ class Queue extends Model
      *
      * @return string
      */
-    public function customImageExists($key)
-    {
+    public function customImageExists($key) {
         return file_exists($this->customImagePath . '/' . $this->CustomImageFileName($key));
     }
 
@@ -442,8 +417,7 @@ class Queue extends Model
      *
      * @return mixed
      */
-    public function getGeneralServiceAttribute()
-    {
+    public function getGeneralServiceAttribute() {
         return (new GeneralService());
     }
 
@@ -452,8 +426,7 @@ class Queue extends Model
      *
      * @return mixed
      */
-    public function configSet($key)
-    {
+    public function configSet($key) {
         if (isset($this->configInfo[$key]) && $this->configInfo[$key] == true) {
             return true;
         }
@@ -465,9 +438,8 @@ class Queue extends Model
      * Retrieves any data that should be used in the holiday type on the user side
      *
      */
-    public function getItemsAttribute()
-    {
-        if (! isset($this->data['items'])) {
+    public function getItemsAttribute() {
+        if (!isset($this->data['items'])) {
             return [];
         }
 
@@ -479,12 +451,16 @@ class Queue extends Model
         return $final;
     }
 
+    /** Gets the staff rank id as a list of ids */
+    public function getStaffRankIdAttribute($value) {
+        return json_decode($value);
+    }
+
     /**********************************************************************************************
     OTHER
      **********************************************************************************************/
 
-    public function checkLimit($user)
-    {
+    public function checkLimit($user) {
         //categories supersede all.
         if ($this->queue_category_id && isset($this->category->limit)) {
             return $this->category->checkLimit($user);
@@ -494,13 +470,11 @@ class Queue extends Model
             if ($this->logCount($user) >= $this->limit) {
                 return false;
             }
-
         }
         return true;
     }
 
-    public function logCount($user)
-    {
+    public function logCount($user) {
         if (isset($this->limit)) {
 
             switch ($this->limit_period) {
@@ -523,13 +497,11 @@ class Queue extends Model
                     return QueueSubmission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfYear())->count();
                     break;
             }
-
         }
         return null;
     }
 
-    public function checkConcurrent($user)
-    {
+    public function checkConcurrent($user) {
         //categories supersede all.
         if ($this->queue_category_id && isset($this->category->limit_concurrent)) {
             return $this->category->checkConcurrent($user);
@@ -539,7 +511,6 @@ class Queue extends Model
             if (QueueSubmission::pending($this->id, $user->id)->count() >= $this->limit_concurrent) {
                 return false;
             }
-
         }
         return true;
     }
@@ -549,8 +520,7 @@ class Queue extends Model
      *
      * @return array
      */
-    public function getRewardsAttribute()
-    {
+    public function getRewardsAttribute() {
         $rewards = [];
         if (isset($this->output['users'])) {
             $assets = $this->getRewardItemsAttribute();
@@ -574,8 +544,7 @@ class Queue extends Model
      *
      * @return array
      */
-    public function getRewardItemsAttribute()
-    {
+    public function getRewardItemsAttribute() {
         return parseAssetData($this->output['users']);
     }
 
@@ -584,8 +553,7 @@ class Queue extends Model
      *
      * @return array
      */
-    public function getCharacterRewardsAttribute()
-    {
+    public function getCharacterRewardsAttribute() {
         $rewards = [];
         if (isset($this->output['characters'])) {
             $assets = $this->getCharacterRewardItemsAttribute();
@@ -609,9 +577,7 @@ class Queue extends Model
      *
      * @return array
      */
-    public function getCharacterRewardItemsAttribute()
-    {
+    public function getCharacterRewardItemsAttribute() {
         return parseAssetData($this->output['characters']);
     }
-
 }

--- a/app/Services/QueueSubmissionManager.php
+++ b/app/Services/QueueSubmissionManager.php
@@ -267,6 +267,7 @@ class QueueSubmissionManager extends Service
                 ]);
 
                 Notifications::create('QUEUE_SUBMISSION_CANCELLED', $submission->user, [
+                    'queue_name'   => $submission->queue->name,
                     'staff_url'     => $user->url,
                     'staff_name'    => $user->name,
                     'submission_id' => $submission->id,
@@ -344,6 +345,7 @@ class QueueSubmissionManager extends Service
             ]);
 
             Notifications::create('QUEUE_SUBMISSION_REJECTED', $submission->user, [
+                'queue_name'   => $submission->queue->name,
                 'staff_url'     => $user->url,
                 'staff_name'    => $user->name,
                 'submission_id' => $submission->id,
@@ -541,6 +543,7 @@ class QueueSubmissionManager extends Service
             ]);
 
             Notifications::create('QUEUE_SUBMISSION_APPROVED', $submission->user, [
+                'queue_name'   => $submission->queue->name,
                 'staff_url'     => $user->url,
                 'staff_name'    => $user->name,
                 'submission_id' => $submission->id,

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -54,4 +54,10 @@ return [
         'default_recipient' => 0, // 0 to default to the character's owner (if a user), 1 to default to the submission user.
     ],
 
+    //queue-creator - SUPERCOOL
+    'queue_creator' => [
+        'expand_in_admin_index' => 0, // 1 un-nests the queues on the admin index page and lists them as individual cards with their own counts instead
+        'expand_in_user_menu' => 0, // 1 un-nests the queue submissions on the user menu page and gives each one a unique page with draft/pending/approved/rejected tabs
+    ]
+
 ];

--- a/config/lorekeeper/notifications.php
+++ b/config/lorekeeper/notifications.php
@@ -411,21 +411,21 @@ return [
     // QUEUE_SUBMISSION_APPROVED
     1116 => [
         'name' => 'Queue Submission Approved',
-        'message' => 'Your submission (#{submission_id}) was approved by <a href="{staff_url}">{staff_name}</a>. (<a href="{url}">View Submission</a>)',
+        'message' => 'Your {queue_name} submission (#{submission_id}) was approved by <a href="{staff_url}">{staff_name}</a>. (<a href="{url}">View Submission</a>)',
         'url' => 'queue-submissions/view/{submission_id}'
     ],
 
     // QUEUE_SUBMISSION_REJECTED
     1117 => [
         'name' => 'Queue Submission Rejected',
-        'message' => 'Your submission (#{submission_id}) was rejected by <a href="{staff_url}">{staff_name}</a>. (<a href="{url}">View Submission</a>)',
+        'message' => 'Your {queue_name} submission (#{submission_id}) was rejected by <a href="{staff_url}">{staff_name}</a>. (<a href="{url}">View Submission</a>)',
         'url' => 'queue-submissions/view/{submission_id}'
     ],
 
      // QUEUE_SUBMISSION_CANCELLED
     1118 => [
         'name'    => 'Queue Submission Cancelled',
-        'message' => 'Your submission (#{submission_id}) was cancelled and sent back to drafts by <a href="{staff_url}">{staff_name}</a>. (<a href="{url}">View Submission</a>)',
+        'message' => 'Your {queue_name} submission (#{submission_id}) was cancelled and sent back to drafts by <a href="{staff_url}">{staff_name}</a>. (<a href="{url}">View Submission</a>)',
         'url'     => 'queue-submissions/view/{submission_id}',
     ],
 ];

--- a/database/migrations/2025_11_03_072821_add_staff_rank_to_queue.php
+++ b/database/migrations/2025_11_03_072821_add_staff_rank_to_queue.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddStaffRankToQueue extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::table('queues', function (Blueprint $table) {
+            $table->text('staff_rank_id')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        Schema::table('queues', function (Blueprint $table) {
+            $table->dropColumn('staff_rank_id');
+        });
+    }
+}

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -1,193 +1,257 @@
 @extends('admin.layout')
 
-@section('admin-title') Dashboard @endsection
+@section('admin-title')
+    Dashboard
+@endsection
 
 @section('admin-content')
-{!! breadcrumbs(['Admin Panel' => 'admin', 'Home' => 'admin']) !!}
+    {!! breadcrumbs(['Admin Panel' => 'admin', 'Home' => 'admin']) !!}
 
-<h1>Admin Dashboard</h1>
-<div class="row">
-    @if (Auth::user()->hasPower('manage_submissions'))
-      <div class="col-sm-6">
-          <div class="card mb-3">
-              <div class="card-body">
-                  <h5 class="card-title">Prompt Submissions @if($submissionCount)<span class="badge badge-primary">{{ $submissionCount }}</span>@endif</h5>
-                  <p class="card-text">
-                      @if($submissionCount)
-                          {{ $submissionCount }} submission{{ $submissionCount == 1 ? '' : 's' }} awaiting processing.
-                      @else
-                          The submission queue is clear. Hooray!
-                      @endif
-                  </p>
-                  <div class="text-right">
-                      <a href="{{ url('admin/submissions/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
-                  </div>
-              </div>
-          </div>
-      </div>
-      <div class="col-sm-6">
-          <div class="card mb-3">
-              <div class="card-body">
-                  <h5 class="card-title">Claims @if($claimCount)<span class="badge badge-primary">{{ $claimCount }}</span>@endif</h5>
-                  <p class="card-text">
-                      @if($claimCount)
-                          {{ $claimCount }} claim{{ $claimCount == 1 ? '' : 's' }} awaiting processing.
-                      @else
-                          The claim queue is clear. Hooray!
-                      @endif
-                  </p>
-                  <div class="text-right">
-                      <a href="{{ url('admin/claims/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
-                  </div>
-              </div>
-          </div>
-      </div>
-      <div class="col-sm-6">
-          <div class="card mb-3">
-              <div class="card-body">
-                  <h5 class="card-title">Queue Submissions @if($queueCount)<span class="badge badge-primary">{{ $queueCount }}</span>@endif</h5>
-                  <p class="card-text">
-                      @if($queueCount)
-                          {{ $queueCount }} custom submission{{ $queueCount == 1 ? '' : 's' }} awaiting processing.
-                      @else
-                          The custom submission queue is clear. Hooray!
-                      @endif
-                  </p>
-                  <div class="text-right">
-                      <a href="{{ url('admin/queue-submissions/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
-                  </div>
-              </div>
-          </div>
-      </div>
-    @endif
-    @if (Auth::user()->hasPower('manage_characters'))
-      <div class="col-sm-6">
-          <div class="card mb-3">
-              <div class="card-body">
-                  <h5 class="card-title">Design Updates @if($designCount)<span class="badge badge-primary">{{ $designCount }}</span>@endif</h5>
-                  <p class="card-text">
-                      @if($designCount)
-                          {{ $designCount }} design update{{ $designCount == 1 ? '' : 's' }} awaiting processing.
-                      @else
-                          The design update approval queue is clear. Hooray!
-                      @endif
-                  </p>
-                  <div class="text-right">
-                      <a href="{{ url('admin/design-approvals/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
-                  </div>
-              </div>
-          </div>
-      </div>
-      <div class="col-sm-6">
-          <div class="card mb-3">
-              <div class="card-body">
-                  <h5 class="card-title">MYO Approvals @if($myoCount)<span class="badge badge-primary">{{ $myoCount }}</span>@endif</h5>
-                  <p class="card-text">
-                      @if($myoCount)
-                          {{ $myoCount }} MYO slot{{ $myoCount == 1 ? '' : 's' }} awaiting processing.
-                      @else
-                          The MYO slot approval queue is clear. Hooray!
-                      @endif
-                  </p>
-                  <div class="text-right">
-                      <a href="{{ url('admin/myo-approvals/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
-                  </div>
-              </div>
-          </div>
-      </div>
-      @if($openTransfersQueue)
-          <div class="col-sm-6">
-              <div class="card mb-3">
-                  <div class="card-body">
-                      <h5 class="card-title">Character Transfers @if($transferCount + $tradeCount)<span class="badge badge-primary">{{ $transferCount + $tradeCount }}</span>@endif</h5>
-                      <p class="card-text">
-                          @if($transferCount + $tradeCount)
-                              {{ $transferCount + $tradeCount }} character transfer{{$transferCount + $tradeCount == 1 ? '' : 's' }} and/or trade{{$transferCount + $tradeCount == 1 ? '' : 's' }} awaiting processing.
-                          @else
-                              The character transfer/trade queue is clear. Hooray!
-                          @endif
-                      </p>
-                      <div class="text-right">
-                          <a href="{{ url('admin/masterlist/transfers/incoming') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
-                      </div>
-                  </div>
-              </div>
-          </div>
-      @endif
-    @endif
-    @if (Auth::user()->hasPower('manage_reports'))
-      <div class="col-sm-6">
-        <div class="card mb-3">
-            <div class="card-body">
-                <h5 class="card-title">Reports @if($reportCount||$assignedReportCount)<span class="badge badge-primary">{{ $reportCount + $assignedReportCount }}</span>@endif</h5>
-                <p class="card-text">
-                    @if($reportCount||$assignedReportCount)
-                        @if($reportCount)
-                            {{ $reportCount }} report{{ $reportCount == 1 ? '' : 's' }} awaiting assignment.
-                        @endif
-                        {!! $reportCount && $assignedReportCount ? '<br/>' : '' !!}
-                        @if($assignedReportCount)
-                            {{ $assignedReportCount }} report{{ $assignedReportCount == 1 ? '' : 's' }} awaiting processing.
-                        @endif
-                    @else
-                        The report queue is clear. Hooray!
+    <h1>
+        Admin Dashboard</h1>
+    <div class="row">
+        @if (Auth::user()->hasPower('manage_submissions'))
+            <div class="col-sm-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Prompt Submissions @if ($submissionCount)
+                                <span class="badge badge-primary">{{ $submissionCount }}</span>
+                            @endif
+                        </h5>
+                        <p class="card-text">
+                            @if ($submissionCount)
+                                {{ $submissionCount }} submission{{ $submissionCount == 1 ? '' : 's' }} awaiting processing.
+                            @else
+                                The submission queue is clear. Hooray!
+                            @endif
+                        </p>
+                        <div class="text-right">
+                            <a href="{{ url('admin/submissions/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Claims @if ($claimCount)
+                                <span class="badge badge-primary">{{ $claimCount }}</span>
+                            @endif
+                        </h5>
+                        <p class="card-text">
+                            @if ($claimCount)
+                                {{ $claimCount }} claim{{ $claimCount == 1 ? '' : 's' }} awaiting processing.
+                            @else
+                                The claim queue is clear. Hooray!
+                            @endif
+                        </p>
+                        <div class="text-right">
+                            <a href="{{ url('admin/claims/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
+
+            @if (config('lorekeeper.extensions.queue_creator.expand_in_admin_index'))
+                @foreach ($queues as $queue)
+                    @if ($queue->staff_rank_id === null || in_array(Auth::user()->rank_id, $queue->staff_rank_id))
+                        <div class="col-sm-6">
+                            <div class="card mb-3">
+                                <div class="card-body">
+                                    @php $queueCount = $queue->submissions('pending')->count(); @endphp
+                                    <h5 class="card-title">{{ $queue->name }} Submissions @if ($queueCount)
+                                            <span class="badge badge-primary">{{ $queueCount }}</span>
+                                        @endif
+                                    </h5>
+                                    <p class="card-text">
+                                        @if ($queueCount)
+                                            {{ $queueCount }} {{ $queue->name }} submission{{ $queueCount == 1 ? '' : 's' }} awaiting processing.
+                                        @else
+                                            The {{ $queue->name }} submission queue is clear. Hooray!
+                                        @endif
+                                    </p>
+                                    <div class="text-right">
+                                        <a href="{{ url('admin/queue-submissions/' . $queue->id . '/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     @endif
+                @endforeach
+            @else
+                <div class="col-sm-6">
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            <h5 class="card-title">Queue Submissions @if ($queueCount)
+                                    <span class="badge badge-primary">{{ $queueCount }}</span>
+                                @endif
+                            </h5>
+                            <p class="card-text">
+                                @if ($queueCount)
+                                    {{ $queueCount }} custom submission{{ $queueCount == 1 ? '' : 's' }} awaiting processing.
+                                @else
+                                    The custom submission queue is clear. Hooray!
+                                @endif
+                            </p>
+                            <div class="text-right">
+                                <a href="{{ url('admin/queue-submissions/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+
+
+        @endif
+        @if (Auth::user()->hasPower('manage_characters'))
+            <div class="col-sm-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Design Updates @if ($designCount)
+                                <span class="badge badge-primary">{{ $designCount }}</span>
+                            @endif
+                        </h5>
+                        <p class="card-text">
+                            @if ($designCount)
+                                {{ $designCount }} design update{{ $designCount == 1 ? '' : 's' }} awaiting processing.
+                            @else
+                                The design update approval queue is clear. Hooray!
+                            @endif
+                        </p>
+                        <div class="text-right">
+                            <a href="{{ url('admin/design-approvals/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">MYO Approvals @if ($myoCount)
+                                <span class="badge badge-primary">{{ $myoCount }}</span>
+                            @endif
+                        </h5>
+                        <p class="card-text">
+                            @if ($myoCount)
+                                {{ $myoCount }} MYO slot{{ $myoCount == 1 ? '' : 's' }} awaiting processing.
+                            @else
+                                The MYO slot approval queue is clear. Hooray!
+                            @endif
+                        </p>
+                        <div class="text-right">
+                            <a href="{{ url('admin/myo-approvals/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            @if ($openTransfersQueue)
+                <div class="col-sm-6">
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            <h5 class="card-title">Character Transfers @if ($transferCount + $tradeCount)
+                                    <span class="badge badge-primary">{{ $transferCount + $tradeCount }}</span>
+                                @endif
+                            </h5>
+                            <p class="card-text">
+                                @if ($transferCount + $tradeCount)
+                                    {{ $transferCount + $tradeCount }} character transfer{{ $transferCount + $tradeCount == 1 ? '' : 's' }} and/or trade{{ $transferCount + $tradeCount == 1 ? '' : 's' }} awaiting processing.
+                                @else
+                                    The character transfer/trade queue is clear. Hooray!
+                                @endif
+                            </p>
+                            <div class="text-right">
+                                <a href="{{ url('admin/masterlist/transfers/incoming') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            @endif
+        @endif
+        @if (Auth::user()->hasPower('manage_reports'))
+            <div class="col-sm-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Reports @if ($reportCount || $assignedReportCount)
+                                <span class="badge badge-primary">{{ $reportCount + $assignedReportCount }}</span>
+                            @endif
+                        </h5>
+                        <p class="card-text">
+                            @if ($reportCount || $assignedReportCount)
+                                @if ($reportCount)
+                                    {{ $reportCount }} report{{ $reportCount == 1 ? '' : 's' }} awaiting assignment.
+                                @endif
+                                {!! $reportCount && $assignedReportCount ? '<br/>' : '' !!}
+                                @if ($assignedReportCount)
+                                    {{ $assignedReportCount }} report{{ $assignedReportCount == 1 ? '' : 's' }} awaiting processing.
+                                @endif
+                            @else
+                                The report queue is clear. Hooray!
+                            @endif
+                        </p>
+                        <div class="text-right">
+                            <a href="{{ url('admin/reports/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endif
+        @if (!Auth::user()->hasPower('manage_submissions') && !Auth::user()->hasPower('manage_characters') && !Auth::user()->hasPower('manage_reports'))
+            <div class="card p-4 col-12">
+                <h5 class="card-title">You do not have a rank that allows you to access any queues.</h5>
+                <p class="mb-1">
+                    Refer to the sidebar for what you can access as a staff member.
                 </p>
-                <div class="text-right">
-                    <a href="{{ url('admin/reports/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                <p class="mb-0">
+                    If you believe this to be in error, contact your site administrator.
+                </p>
+            </div>
+        @endif
+        @if ($galleryRequireApproval)
+            <div class="col-sm-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Gallery Submissions @if ($gallerySubmissionCount)
+                                <span class="badge badge-primary">{{ $gallerySubmissionCount }}</span>
+                            @endif
+                        </h5>
+                        <p class="card-text">
+                            @if ($gallerySubmissionCount)
+                                {{ $gallerySubmissionCount }} gallery submission{{ $gallerySubmissionCount == 1 ? '' : 's' }} awaiting processing.
+                            @else
+                                The gallery submission queue is clear. Hooray!
+                            @endif
+                        </p>
+                        <div class="text-right">
+                            <a href="{{ url('admin/gallery/submissions/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
+        @endif
+        @if ($galleryCurrencyAwards)
+            <div class="col-sm-6">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">Gallery Currency Awards @if ($galleryAwardCount)
+                                <span class="badge badge-primary">{{ $galleryAwardCount }}</span>
+                            @endif
+                        </h5>
+                        <p class="card-text">
+                            @if ($galleryAwardCount)
+                                {{ $galleryAwardCount }} gallery submission{{ $galleryAwardCount == 1 ? '' : 's' }} awaiting currency rewards.
+                            @else
+                                The gallery currency award queue is clear. Hooray!
+                            @endif
+                        </p>
+                        <div class="text-right">
+                            <a href="{{ url('admin/gallery/currency/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endif
     </div>
-    @endif
-    @if(!Auth::user()->hasPower('manage_submissions') && !Auth::user()->hasPower('manage_characters') && !Auth::user()->hasPower('manage_reports'))
-      <div class="card p-4 col-12">
-        <h5 class="card-title">You do not have a rank that allows you to access any queues.</h5>
-        <p class="mb-1">
-           Refer to the sidebar for what you can access as a staff member.
-        </p>
-        <p class="mb-0">
-          If you believe this to be in error, contact your site administrator.
-        </p>
-      </div>
-    @endif
-    @if($galleryRequireApproval)
-        <div class="col-sm-6">
-            <div class="card mb-3">
-                <div class="card-body">
-                    <h5 class="card-title">Gallery Submissions @if($gallerySubmissionCount)<span class="badge badge-primary">{{ $gallerySubmissionCount }}</span>@endif</h5>
-                    <p class="card-text">
-                        @if($gallerySubmissionCount)
-                            {{ $gallerySubmissionCount }} gallery submission{{$gallerySubmissionCount == 1 ? '' : 's' }} awaiting processing.
-                        @else
-                            The gallery submission queue is clear. Hooray!
-                        @endif
-                    </p>
-                    <div class="text-right">
-                        <a href="{{ url('admin/gallery/submissions/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    @endif
-    @if($galleryCurrencyAwards)
-        <div class="col-sm-6">
-            <div class="card mb-3">
-                <div class="card-body">
-                    <h5 class="card-title">Gallery Currency Awards @if($galleryAwardCount)<span class="badge badge-primary">{{ $galleryAwardCount }}</span>@endif</h5>
-                    <p class="card-text">
-                        @if($galleryAwardCount)
-                            {{ $galleryAwardCount }} gallery submission{{$galleryAwardCount == 1 ? '' : 's' }} awaiting currency rewards.
-                        @else
-                            The gallery currency award queue is clear. Hooray!
-                        @endif
-                    </p>
-                    <div class="text-right">
-                        <a href="{{ url('admin/gallery/currency/pending') }}" class="card-link">View Queue <span class="fas fa-caret-right ml-1"></span></a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    @endif
-</div>
 @endsection

--- a/resources/views/admin/queues/create_edit_queue.blade.php
+++ b/resources/views/admin/queues/create_edit_queue.blade.php
@@ -40,9 +40,19 @@
         @endif
     </div>
 
-    <div class="form-group">
-        {!! Form::label('Queue Category (Optional)') !!}
-        {!! Form::select('queue_category_id', $categories, $queue->queue_category_id, ['class' => 'form-control']) !!}
+    <div class="row">
+        <div class="col-md-6">
+            <div class="form-group">
+                {!! Form::label('Queue Category (Optional)') !!}
+                {!! Form::select('queue_category_id', $categories, $queue->queue_category_id, ['class' => 'form-control']) !!}
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="form-group">
+                {!! Form::label('Associated Staff Ranks (Optional)') !!}{!! add_help('Queues are shown to all staff with the submission power by default. Setting this makes it so that only selected ranks will see this queue.') !!}
+                {!! Form::select('staff_rank_id[]', $ranks, $queue->staff_rank_id, ['class' => 'form-control selectize', 'multiple']) !!}
+            </div>
+        </div>
     </div>
 
     <div class="form-group">
@@ -315,6 +325,8 @@
     @include('js._loot_js', ['showLootTables' => true, 'showRaffles' => true, 'prefix' => 'user_'])
     @include('js._loot_js', ['showLootTables' => true, 'showRaffles' => true, 'prefix' => 'character_', 'isCharacter' => true])
     <script>
+        $('.selectize').selectize();
+
         $(document).ready(function() {
             $('.delete-queue-button').on('click', function(e) {
                 e.preventDefault();

--- a/resources/views/admin/queues/submission_index.blade.php
+++ b/resources/views/admin/queues/submission_index.blade.php
@@ -5,31 +5,33 @@
 @endsection
 
 @section('admin-content')
-        {!! breadcrumbs(['Admin Panel' => 'admin', 'Queue Submissions' => 'admin/queue-submissions/pending']) !!}
+    {!! breadcrumbs(['Admin Panel' => 'admin', 'Queue Submissions' => 'admin/queue-submissions/pending']) !!}
 
     <h1>
-        Queue Submissions
+        {{ isset($queue) ? $queue->name : 'Queue' }} Submissions
     </h1>
 
     <ul class="nav nav-tabs mb-3">
         <li class="nav-item">
-            <a class="nav-link {{ set_active('admin/queue-submissions/pending*') }} {{ set_active('admin/queue-submissions') }}"
-                href="{{ url('admin/queue-submissions/pending') }}">Pending</a>
+            <a class="nav-link {{ set_active('admin/queue-submissions/' . (isset($queue) ? $queue->id . '/' : '') . 'pending*') }} {{ set_active('admin/queue-submissions' . (isset($queue) ? '/' . $queue->id : '')) }}"
+               href="{{ url('admin/queue-submissions/' . (isset($queue) ? $queue->id . '/' : '') . 'pending') }}">Pending</a>
         </li>
         <li class="nav-item">
-            <a class="nav-link {{ set_active('admin/queue-submissions/approved*') }}" href="{{ url('admin/queue-submissions/approved') }}">Approved</a>
+            <a class="nav-link {{ set_active('admin/queue-submissions/' . (isset($queue) ? $queue->id . '/' : '') . 'approved*') }}" href="{{ url('admin/queue-submissions/' . (isset($queue) ? $queue->id . '/' : '') . 'approved') }}">Approved</a>
         </li>
         <li class="nav-item">
-            <a class="nav-link {{ set_active('admin/queue-submissions/rejected*') }}" href="{{ url('admin/queue-submissions/rejected') }}">Rejected</a>
+            <a class="nav-link {{ set_active('admin/queue-submissions/' . (isset($queue) ? $queue->id . '/' : '') . 'rejected*') }}" href="{{ url('admin/queue-submissions/' . (isset($queue) ? $queue->id . '/' : '') . 'rejected') }}">Rejected</a>
         </li>
     </ul>
 
     {!! Form::open(['method' => 'GET', 'class' => 'form-inline justify-content-end']) !!}
-    <div class="form-inline justify-content-end">
+    @if (!isset($queue))
+        <div class="form-inline justify-content-end">
             <div class="form-group ml-3 mb-3">
                 {!! Form::select('queue_category_id', $categories, Request::get('queue_category_id'), ['class' => 'form-control']) !!}
             </div>
-    </div>
+        </div>
+    @endif
     <div class="form-inline justify-content-end">
         <div class="form-group ml-3 mb-3">
             {!! Form::select(
@@ -52,9 +54,11 @@
     <div class="mb-4 logs-table">
         <div class="logs-table-header">
             <div class="row">
+                @if (!isset($queue))
                     <div class="col-12 col-md-2">
                         <div class="logs-table-cell">Queue</div>
                     </div>
+                @endif
                 <div class="col-6 col-md-2">
                     <div class="logs-table-cell">User</div>
                 </div>
@@ -70,9 +74,11 @@
             @foreach ($submissions as $submission)
                 <div class="logs-table-row">
                     <div class="row flex-wrap">
+                        @if (!isset($queue))
                             <div class="col-12 col-md-2">
                                 <div class="logs-table-cell">{!! $submission->queue->displayName !!}</div>
                             </div>
+                        @endif
                         <div class="col-6 col-md-2">
                             <div class="logs-table-cell">{!! $submission->user->displayName !!}</div>
                         </div>

--- a/resources/views/home/_sidebar.blade.php
+++ b/resources/views/home/_sidebar.blade.php
@@ -13,7 +13,14 @@
         <div class="sidebar-item"><a href="{{ url('claims') }}" class="{{ set_active('claims*') }}">Claims</a></div>
         <div class="sidebar-item"><a href="{{ url('characters/transfers/incoming') }}" class="{{ set_active('characters/transfers*') }}">Character Transfers</a></div>
         <div class="sidebar-item"><a href="{{ url('trades/open') }}" class="{{ set_active('trades/open*') }}">Trades</a></div>
-        <div class="sidebar-item"><a href="{{ url('queue-submissions') }}" class="{{ set_active('queue-submissions*') }}">Queue Submissions</a></div>
+        @if (config('lorekeeper.extensions.queue_creator.expand_in_user_menu'))
+            @php $queues = \App\Models\Queue\Queue::get(); @endphp
+            @foreach ($queues as $queue)
+                <div class="sidebar-item"><a href="{{ url('queue-submissions/' . $queue->id) }}" class="{{ set_active('queue-submissions/' . $queue->id) }}">{{ $queue->name }} Submissions</a></div>
+            @endforeach
+        @else
+            <div class="sidebar-item"><a href="{{ url('queue-submissions') }}" class="{{ set_active('queue-submissions*') }}">Queue Submissions</a></div>
+        @endif
     </li>
     <li class="sidebar-section">
         <div class="sidebar-section-header">Reports</div>

--- a/resources/views/home/_sidebar.blade.php
+++ b/resources/views/home/_sidebar.blade.php
@@ -14,7 +14,7 @@
         <div class="sidebar-item"><a href="{{ url('characters/transfers/incoming') }}" class="{{ set_active('characters/transfers*') }}">Character Transfers</a></div>
         <div class="sidebar-item"><a href="{{ url('trades/open') }}" class="{{ set_active('trades/open*') }}">Trades</a></div>
         @if (config('lorekeeper.extensions.queue_creator.expand_in_user_menu'))
-            @php $queues = \App\Models\Queue\Queue::get(); @endphp
+            @php $queues = \App\Models\Queue\Queue::query()->active()->get(); @endphp
             @foreach ($queues as $queue)
                 <div class="sidebar-item"><a href="{{ url('queue-submissions/' . $queue->id) }}" class="{{ set_active('queue-submissions/' . $queue->id) }}">{{ $queue->name }} Submissions</a></div>
             @endforeach

--- a/resources/views/home/queues/submissions.blade.php
+++ b/resources/views/home/queues/submissions.blade.php
@@ -8,22 +8,30 @@
 
     {!! breadcrumbs(['Queue Submissions' => 'queue-submissions']) !!}
 
+    @if (isset($queue))
+        <div class="float-right">
+            <a href="{{ url('queue-submissions/new/' . $queue->id) }}" class="btn btn-success">New Submission</a>
+        </div>
+    @endif
+
     <h1>
-        Queue Submissions
+        {{ isset($queue) ? $queue->name : 'Queue' }} Submissions
     </h1>
+
+
 
     <ul class="nav nav-tabs mb-3">
         <li class="nav-item">
-            <a class="nav-link {{ Request::get('type') == 'draft' ? 'active' : '' }}" href="queue-submissions?type=draft">Drafts</a>
+            <a class="nav-link {{ Request::get('type') == 'draft' ? 'active' : '' }}" href="/queue-submissions{{ isset($queue) ? '/' . $queue->id : '' }}?type=draft">Drafts</a>
         </li>
         <li class="nav-item">
-            <a class="nav-link {{ !Request::get('type') || Request::get('type') == 'pending' ? 'active' : '' }}" href="queue-submissions">Pending</a>
+            <a class="nav-link {{ !Request::get('type') || Request::get('type') == 'pending' ? 'active' : '' }}" href="/queue-submissions{{ isset($queue) ? '/' . $queue->id : '' }}">Pending</a>
         </li>
         <li class="nav-item">
-            <a class="nav-link {{ Request::get('type') == 'approved' ? 'active' : '' }}" href="queue-submissions?type=approved">Approved</a>
+            <a class="nav-link {{ Request::get('type') == 'approved' ? 'active' : '' }}" href="/queue-submissions{{ isset($queue) ? '/' . $queue->id : '' }}?type=approved">Approved</a>
         </li>
         <li class="nav-item">
-            <a class="nav-link {{ Request::get('type') == 'rejected' ? 'active' : '' }}" href="queue-submissions?type=rejected">Rejected</a>
+            <a class="nav-link {{ Request::get('type') == 'rejected' ? 'active' : '' }}" href="/queue-submissions{{ isset($queue) ? '/' . $queue->id : '' }}?type=rejected">Rejected</a>
         </li>
     </ul>
 
@@ -32,9 +40,11 @@
         <div class="mb-4 logs-table">
             <div class="logs-table-header">
                 <div class="row">
-                    <div class="col-12 col-md-2 font-weight-bold">
-                        <div class="logs-table-cell">Queue</div>
-                    </div>
+                    @if (!isset($queue))
+                        <div class="col-12 col-md-2 font-weight-bold">
+                            <div class="logs-table-cell">Queue</div>
+                        </div>
+                    @endif
                     <div class="col-6 col-md-5 font-weight-bold">
                         <div class="logs-table-cell">Last Action</div>
                     </div>
@@ -47,9 +57,11 @@
                 @foreach ($submissions as $submission)
                     <div class="logs-table-row">
                         <div class="row flex-wrap">
-                            <div class="col-12 col-md-2">
-                                <div class="logs-table-cell">{!! $submission->queue->displayName !!}</div>
-                            </div>
+                            @if (!isset($queue))
+                                <div class="col-12 col-md-2">
+                                    <div class="logs-table-cell">{!! $submission->queue->displayName !!}</div>
+                                </div>
+                            @endif
                             <div class="col-6 col-md-5">
                                 <div class="logs-table-cell">{!! pretty_date($submission->updated_at) !!}</div>
                             </div>

--- a/routes/lorekeeper/admin.php
+++ b/routes/lorekeeper/admin.php
@@ -462,6 +462,8 @@ Route::get('{type}/{status}', 'DesignController@getDesignIndex')->where('type', 
 Route::group(['prefix' => 'queue-submissions', 'middleware' => 'power:manage_submissions'], function() {
     Route::get('/', 'QueueSubmissionController@getSubmissionIndex');
     Route::get('/{status}', 'QueueSubmissionController@getSubmissionIndex')->where('status', 'pending|approved|rejected');
+    Route::get('/{id}', 'QueueSubmissionController@getQueueSubmissionIndex');
+    Route::get('/{id}/{status}', 'QueueSubmissionController@getQueueSubmissionIndex')->where('status', 'pending|approved|rejected');
     Route::get('edit/{id}', 'QueueSubmissionController@getSubmission');
-    Route::post('edit/{id}/{action}', 'QueueSubmissionController@postSubmission')->where('action', 'approve|reject');
+    Route::post('edit/{id}/{action}', 'QueueSubmissionController@postSubmission')->where('action', 'approve|reject|cancel');
 });

--- a/routes/lorekeeper/members.php
+++ b/routes/lorekeeper/members.php
@@ -181,6 +181,7 @@ Route::group(['prefix' => 'designs', 'namespace' => 'Characters'], function() {
 
 Route::group(['prefix' => 'queue-submissions', 'namespace' => 'Users'], function () {
     Route::get('/', 'QueueSubmissionController@getIndex');
+    Route::get('/{id}', 'QueueSubmissionController@getIndex');
     Route::get('new/{id}', 'QueueSubmissionController@getNewSubmission')->where(['id' => '[0-9]+']);
     Route::get('new/character/{slug}', 'QueueSubmissionController@getCharacterInfo');
     Route::post('new/{id}', 'QueueSubmissionController@postNewSubmission');


### PR DESCRIPTION
Apologies in advance that my formatter hit a couple of these pages a little hard.

Includes the following updates:
- Adds the name of the specific queue to notifications related to said queue
- Adds an extension configuration to allow for expanding queues into the admin index with their own separated submissions pages:
<img width="798" height="419" alt="Screenshot 2025-11-03 at 3 06 22 AM" src="https://github.com/user-attachments/assets/56327d0b-3f68-4ace-9f44-c10066dc33e8" />
- Adds an extension configuration to allow for expanding queues into the home sidebar:
<img width="1033" height="505" alt="Screenshot 2025-11-03 at 3 06 58 AM" src="https://github.com/user-attachments/assets/5da754aa-eb45-466c-9804-2d7a963adfa4" />
- Adds the ability to associate ranks with a queue for more fine grained access control compared to submissions power.
