### PR TITLE
Fix for staff only queues showing to users

### DIFF
--- a/app/Http/Controllers/Users/QueueSubmissionController.php
+++ b/app/Http/Controllers/Users/QueueSubmissionController.php
@@ -40,15 +40,15 @@ class QueueSubmissionController extends Controller
     public function getIndex(Request $request, $id = null)
     {
         $submissions = QueueSubmission::with('queue')->where('user_id', Auth::user()->id)->whereNotNull('queue_id')->whereHas('queue', function ($query) {
-            return $query->active();
+            return $query->active()->staffOnly(Auth::user());
         });
         $type        = $request->get('type');
         if (! $type) {
             $type = 'Pending';
         }
 
-        $queue = Queue::find($id);
-        if (isset($queue) && !$queue->is_active) abort(404);
+        $queue = Queue::active()->staffOnly(Auth::user())->find($id);
+        if (isset($id) && !$queue) abort(404);
         if (isset($id))
             $submissions = $submissions->where('queue_id', $id);
 
@@ -78,6 +78,9 @@ class QueueSubmissionController extends Controller
         }
 
         $queue = $submission->queue;
+        if (!$queue || ($queue->staff_only && !Auth::user()->isStaff)) {
+            abort(404);
+        }
 
         return view('home.queues.submission', [
             'submission' => $submission,
@@ -97,8 +100,7 @@ class QueueSubmissionController extends Controller
     public function getNewSubmission(Request $request, $id)
     {
         $closed = ! Settings::get('is_queue_open');
-
-        $queue = Queue::active()->find($id);
+        $queue = Queue::active()->staffOnly(Auth::user())->find($id);
         if (! $queue) {
             abort(404);
         }

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -57,7 +57,7 @@ return [
     //queue-creator - SUPERCOOL
     'queue_creator' => [
         'expand_in_admin_index' => 0, // 1 un-nests the queues on the admin index page and lists them as individual cards with their own counts instead
-        'expand_in_user_menu' => 1, // 1 un-nests the queue submissions on the user menu page and gives each one a unique page with draft/pending/approved/rejected tabs
+        'expand_in_user_menu' => 0, // 1 un-nests the queue submissions on the user menu page and gives each one a unique page with draft/pending/approved/rejected tabs
     ]
 
 ];

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -57,7 +57,7 @@ return [
     //queue-creator - SUPERCOOL
     'queue_creator' => [
         'expand_in_admin_index' => 0, // 1 un-nests the queues on the admin index page and lists them as individual cards with their own counts instead
-        'expand_in_user_menu' => 0, // 1 un-nests the queue submissions on the user menu page and gives each one a unique page with draft/pending/approved/rejected tabs
+        'expand_in_user_menu' => 1, // 1 un-nests the queue submissions on the user menu page and gives each one a unique page with draft/pending/approved/rejected tabs
     ]
 
 ];

--- a/resources/views/home/_sidebar.blade.php
+++ b/resources/views/home/_sidebar.blade.php
@@ -14,7 +14,7 @@
         <div class="sidebar-item"><a href="{{ url('characters/transfers/incoming') }}" class="{{ set_active('characters/transfers*') }}">Character Transfers</a></div>
         <div class="sidebar-item"><a href="{{ url('trades/open') }}" class="{{ set_active('trades/open*') }}">Trades</a></div>
         @if (config('lorekeeper.extensions.queue_creator.expand_in_user_menu'))
-            @php $queues = \App\Models\Queue\Queue::query()->active()->get(); @endphp
+            @php $queues = \App\Models\Queue\Queue::query()->active()->staffOnly(Auth::user())->get(); @endphp
             @foreach ($queues as $queue)
                 <div class="sidebar-item"><a href="{{ url('queue-submissions/' . $queue->id) }}" class="{{ set_active('queue-submissions/' . $queue->id) }}">{{ $queue->name }} Submissions</a></div>
             @endforeach


### PR DESCRIPTION
Wanted to use staff only to setup the queue I'm making to start with and realized that I hadn't guarded the sidebar against it and that the pages weren't either.